### PR TITLE
support running on pod GitHub runner

### DIFF
--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -88,6 +88,8 @@ module AwsOneClickStaging
 
     def setup_aws_credentials_and_configs
       puts "setup_aws_credentials_and_configs"
+      puts "@staging_creds:"
+      puts @staging_creds
       @staging_creds = setup_aws_credentials(@config['staging'] || @config)
       puts "@staging_creds:"
       puts @staging_creds

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -119,14 +119,25 @@ module AwsOneClickStaging
       missing = CREDENTIAL_KEYS.select do |key|
         !config[key]
       end
+
+      #check if there are some credentials on the machine
+      begin
+        identity = Aws::STS::Client.new().get_caller_identity
+      rescue => e
+        p "no credentials"
+      else
+        p "the credentials are:"
+        p identity
+      end
+
       if missing.none?
         puts "setup_aws_credentials missing.none?"
         access_key_id = config["aws_access_key_id"]
         secret_access_key = config["aws_secret_access_key"]
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
       end
-      if missing.any? && `ec2metadata 2>/dev/null`.empty?
-      puts "setup_aws_credentials missing.any?"
+      if missing.any? && `ec2metadata 2>/dev/null`.empty? && identity.nil?
+        puts "setup_aws_credentials missing.any?"
         raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
       end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -38,7 +38,7 @@ module AwsOneClickStaging
         snapshot_state = get_fresh_db_snapshot_state rescue nil
         puts snapshot_state
         if snapshot_state && snapshot_state.snapshot_create_time >= reuse_since
-          puts "encrypted snapshot"
+          puts "use existing encrypted snapshot"
           @encrypted_snapshot = snapshot_state.encrypted
           puts @encrypted_snapshot
           return
@@ -51,6 +51,7 @@ module AwsOneClickStaging
     end
 
     def clone_encrypted_snapshot(reuse_since: nil)
+      puts "clone_encrypted_snapshot"
       return unless @config['production'] && @encrypted_snapshot
       return unless @config['production'] && encrypted_snapshot
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -80,15 +80,18 @@ module AwsOneClickStaging
     private
 
     def setup_aws_credentials_and_configs
+      puts "setup_aws_credentials_and_configs"
       @staging_creds = setup_aws_credentials(@config['staging'] || @config)
       Aws.config.update @staging_creds
       @c_staging = Aws::RDS::Client.new
       if @config['production']
         @production_creds = setup_aws_credentials(@config['production'])
         @c_production = Aws::RDS::Client.new(@production_creds)
+        puts "setup_aws_credentials_and_configs production"
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
+        puts "setup_aws_credentials_and_configs else production"
       end
 
       @aws_production_bucket = @config["aws_production_bucket"]
@@ -101,7 +104,7 @@ module AwsOneClickStaging
 
     def setup_aws_credentials config
       cred_hash = {}
-
+      puts config
       aws_region = config["aws_region"]
 
       missing = CREDENTIAL_KEYS.select do |key|

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -124,10 +124,10 @@ module AwsOneClickStaging
         secret_access_key = config["aws_secret_access_key"]
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
       end
-      if missing.any? && `ec2metadata 2>/dev/null`.empty?
-      puts "setup_aws_credentials missing.any?"
-        #raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
-      end
+      #if missing.any? && `ec2metadata 2>/dev/null`.empty?
+      #puts "setup_aws_credentials missing.any?"
+      #  raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
+      #end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?
         aws_region = `ec2metadata --availability-zone`.chomp[0..-2]
         puts "setup_aws_credentials !config region && !ec2metadata"

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -20,6 +20,7 @@ module AwsOneClickStaging
         puts "initialize else @config = config"
       end
       puts @config
+      puts "yep.."
       setup_aws_credentials_and_configs
       puts @config
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -19,10 +19,8 @@ module AwsOneClickStaging
         @config = ConfigFile.load(file)
         puts "initialize else @config = config"
       end
-      puts "yep.."
-      #puts @config
-      setup_aws_credentials_and_configs
       puts @config
+      setup_aws_credentials_and_configs
     end
 
     ## reuse_since: don't recreate snapshots if their newer than this

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -108,11 +108,8 @@ module AwsOneClickStaging
       #check if there are some credentials on the machine
       begin
         identity = Aws::STS::Client.new().get_caller_identity
-      rescue => e
+      rescue StandardError => e
         p "no credentials"
-      else
-        p "the credentials are:"
-        p identity
       end
 
       if missing.none?

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -32,10 +32,15 @@ module AwsOneClickStaging
     end
 
     def recreate_snapshot(reuse_since: nil)
+      puts "recreate_snapshot"
       if reuse_since
+        puts "recreate_snapshot reuse_since"
         snapshot_state = get_fresh_db_snapshot_state rescue nil
+        puts snapshot_state
         if snapshot_state && snapshot_state.snapshot_create_time >= reuse_since
+          puts "encrypted snapshot"
           @encrypted_snapshot = snapshot_state.encrypted
+          puts @encrypted_snapshot
           return
         end
       end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -88,14 +88,10 @@ module AwsOneClickStaging
 
     def setup_aws_credentials_and_configs
       puts "setup_aws_credentials_and_configs"
+      @staging_creds = setup_aws_credentials(@config['staging'] || @config)
       puts "@staging_creds:"
       puts @staging_creds
-      if @staging_creds.nil?
-        @staging_creds = setup_aws_credentials(@config['staging'] || @config)
-        puts "@staging_creds:"
-        puts @staging_creds
-        Aws.config.update @staging_creds
-      end
+      Aws.config.update @staging_creds
       @c_staging = Aws::RDS::Client.new
       if @config['production']
         @production_creds = setup_aws_credentials(@config['production'])

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -208,6 +208,9 @@ module AwsOneClickStaging
     def create_encrypted_snapshot_copy!
       puts 'copying shared encrypted snapshot...'
       puts @c_staging
+      puts "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}"
+      puts @db_snapshot_id
+      puts @config['kms_key_id']
 
       @c_staging.copy_db_snapshot(
         source_db_snapshot_identifier: "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}",

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -212,6 +212,15 @@ module AwsOneClickStaging
       puts @db_snapshot_id
       puts @config['kms_key_id']
 
+      begin
+        identity = Aws::STS::Client.new().get_caller_identity
+      rescue => e
+        p "no credentials"
+      else
+        p "the credentials are:"
+        p identity
+      end
+
       @c_staging.copy_db_snapshot(
         source_db_snapshot_identifier: "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}",
         target_db_snapshot_identifier: @db_snapshot_id,

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -88,10 +88,14 @@ module AwsOneClickStaging
 
     def setup_aws_credentials_and_configs
       puts "setup_aws_credentials_and_configs"
-      @staging_creds = setup_aws_credentials(@config['staging'] || @config)
       puts "@staging_creds:"
       puts @staging_creds
-      Aws.config.update @staging_creds
+      if @staging_creds.nil?
+        @staging_creds = setup_aws_credentials(@config['staging'] || @config)
+        puts "@staging_creds:"
+        puts @staging_creds
+        Aws.config.update @staging_creds
+      end
       @c_staging = Aws::RDS::Client.new
       if @config['production']
         @production_creds = setup_aws_credentials(@config['production'])

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -126,7 +126,7 @@ module AwsOneClickStaging
       end
       if missing.any? && `ec2metadata 2>/dev/null`.empty?
       puts "setup_aws_credentials missing.any?"
-        raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
+        #raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
       end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?
         aws_region = `ec2metadata --availability-zone`.chomp[0..-2]

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -21,6 +21,7 @@ module AwsOneClickStaging
       end
       puts @config
       setup_aws_credentials_and_configs
+      puts @config
     end
 
     ## reuse_since: don't recreate snapshots if their newer than this

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -14,17 +14,13 @@ module AwsOneClickStaging
     def initialize file: nil, config: nil
       if config
         @config = config
-        puts "initialize @config = config"
       else
         @config = ConfigFile.load(file)
-        puts "initialize else @config = config"
       end
-      puts "yo"
-      puts @config
       setup_aws_credentials_and_configs
     end
 
-    ## reuse_since: don't recreate snapshots if their newer than this
+    # reuse_since: don't recreate snapshots if their newer than this
     def clone_rds(reuse_since: nil)
       new_snapshot = recreate_snapshot(reuse_since: reuse_since)
       clone_encrypted_snapshot(reuse_since: new_snapshot ? nil : reuse_since)
@@ -32,15 +28,10 @@ module AwsOneClickStaging
     end
 
     def recreate_snapshot(reuse_since: nil)
-      puts "recreate_snapshot"
       if reuse_since
-        puts "recreate_snapshot reuse_since"
         snapshot_state = get_fresh_db_snapshot_state rescue nil
-        puts snapshot_state
         if snapshot_state && snapshot_state.snapshot_create_time >= reuse_since
-          puts "use existing encrypted snapshot"
           @encrypted_snapshot = snapshot_state.encrypted
-          puts @encrypted_snapshot
           return
         end
       end
@@ -51,7 +42,6 @@ module AwsOneClickStaging
     end
 
     def clone_encrypted_snapshot(reuse_since: nil)
-      puts "clone_encrypted_snapshot"
       return unless @config['production'] && @encrypted_snapshot
       return unless @config['production'] && encrypted_snapshot
 
@@ -72,10 +62,6 @@ module AwsOneClickStaging
     end
 
     def clone_s3_bucket
-      puts "clone_s3_bucket"
-      puts "@aws_production_bucket is #{@aws_production_bucket}"
-      puts "@aws_staging_bucket is #{@aws_staging_bucket}"
-      puts "@staging_creds is #{@staging_creds}"
       bs = BucketSyncService.new(@aws_production_bucket, @aws_staging_bucket,
                                  @staging_creds, @config['bucket_prefix'])
       bs.debug = true
@@ -91,20 +77,12 @@ module AwsOneClickStaging
     private
 
     def setup_aws_credentials_and_configs
-      puts "setup_aws_credentials_and_configs"
-      puts "@staging_creds:"
-      puts @staging_creds
       @staging_creds = setup_aws_credentials(@config['staging'] || @config)
-      puts "@staging_creds:"
-      puts @staging_creds
       Aws.config.update @staging_creds
       @c_staging = Aws::RDS::Client.new
       if @config['production']
         @production_creds = setup_aws_credentials(@config['production'])
         @c_production = Aws::RDS::Client.new(@production_creds)
-        puts "setup_aws_credentials_and_configs production"
-        puts "@production_creds:"
-        puts @production_creds
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
@@ -122,9 +100,6 @@ module AwsOneClickStaging
     end
 
     def setup_aws_credentials config
-      puts "setup_aws_credentials"
-      puts "config:"
-      puts config
       cred_hash = {}
       aws_region = config["aws_region"]
 
@@ -149,12 +124,10 @@ module AwsOneClickStaging
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
       end
       if missing.any? && `ec2metadata 2>/dev/null`.empty? && identity.nil?
-        puts "setup_aws_credentials missing.any?"
         raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
       end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?
         aws_region = `ec2metadata --availability-zone`.chomp[0..-2]
-        puts "setup_aws_credentials !config region && !ec2metadata"
       end
       cred_hash.update(region: aws_region)
 
@@ -170,8 +143,6 @@ module AwsOneClickStaging
           region: aws_region,
         }
       end
-      puts "setup_aws_credentials cred_hash:"
-      puts cred_hash
       cred_hash
     end
 
@@ -214,19 +185,6 @@ module AwsOneClickStaging
 
     def create_encrypted_snapshot_copy!
       puts 'copying shared encrypted snapshot...'
-      puts @c_staging
-      puts "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}"
-      puts @db_snapshot_id
-      puts @config['kms_key_id']
-
-      begin
-        identity = Aws::STS::Client.new().get_caller_identity
-      rescue => e
-        p "no credentials"
-      else
-        p "the credentials are:"
-        p identity
-      end
 
       @c_staging.copy_db_snapshot(
         source_db_snapshot_identifier: "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}",
@@ -288,12 +246,10 @@ module AwsOneClickStaging
     end
 
     def get_fresh_db_instance_state(db_instance_id)
-      puts "get_fresh_db_instance_state"
       @c_staging.describe_db_instances(db_instance_identifier: db_instance_id).db_instances.first
     end
 
     def db_instance_is_deleted?(db_instance_id)
-      puts "db_instance_is_deleted?"
       get_fresh_db_instance_state(db_instance_id)
       false
     rescue Aws::RDS::Errors::DBInstanceNotFound

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -62,7 +62,7 @@ module AwsOneClickStaging
 
       delete_encrypted_copy!
       create_encrypted_snapshot_copy!
-#      delete_snapshot_for_staging!
+      delete_snapshot_for_staging!
       true
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -72,12 +72,16 @@ module AwsOneClickStaging
     end
 
     def clone_s3_bucket
+      puts "clone_s3_bucket"
+      puts "@aws_production_bucket is #{@aws_production_bucket}"
+      puts "@aws_staging_bucket is #{@aws_staging_bucket}"
+      puts "@staging_creds is #{@staging_creds}"
       bs = BucketSyncService.new(@aws_production_bucket, @aws_staging_bucket,
                                  @staging_creds, @config['bucket_prefix'])
       bs.debug = true
 
       puts "beginning clone of S3 bucket, this can go on for tens of minutes..."
-      bs.perform
+#      bs.perform
     end
 
     def get_fancy_string_of_staging_db_uri

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -81,7 +81,7 @@ module AwsOneClickStaging
       bs.debug = true
 
       puts "beginning clone of S3 bucket, this can go on for tens of minutes..."
-#      bs.perform
+      bs.perform
     end
 
     def get_fancy_string_of_staging_db_uri

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -238,7 +238,7 @@ module AwsOneClickStaging
     end
 
     def delete_staging_db_instance!
-      puts "Deleting old staging instance..."
+      puts "Deleting old staging instance...#{@db_instance_id_staging}"
       @c_staging.delete_db_instance(db_instance_identifier: @db_instance_id_staging,
         skip_final_snapshot: true)
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -19,8 +19,8 @@ module AwsOneClickStaging
         @config = ConfigFile.load(file)
         puts "initialize else @config = config"
       end
-      puts @config
       puts "yep.."
+      puts @config
       setup_aws_credentials_and_configs
       puts @config
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -19,6 +19,7 @@ module AwsOneClickStaging
         @config = ConfigFile.load(file)
         puts "initialize else @config = config"
       end
+      puts "yo"
       puts @config
       setup_aws_credentials_and_configs
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -20,7 +20,7 @@ module AwsOneClickStaging
         puts "initialize else @config = config"
       end
       puts "yep.."
-      puts @config
+      #puts @config
       setup_aws_credentials_and_configs
       puts @config
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -23,7 +23,7 @@ module AwsOneClickStaging
       setup_aws_credentials_and_configs
     end
 
-    # reuse_since: don't recreate snapshots if their newer than this
+    ## reuse_since: don't recreate snapshots if their newer than this
     def clone_rds(reuse_since: nil)
       new_snapshot = recreate_snapshot(reuse_since: reuse_since)
       clone_encrypted_snapshot(reuse_since: new_snapshot ? nil : reuse_since)
@@ -82,16 +82,19 @@ module AwsOneClickStaging
     def setup_aws_credentials_and_configs
       puts "setup_aws_credentials_and_configs"
       @staging_creds = setup_aws_credentials(@config['staging'] || @config)
+      puts @staging_creds
       Aws.config.update @staging_creds
       @c_staging = Aws::RDS::Client.new
       if @config['production']
         @production_creds = setup_aws_credentials(@config['production'])
         @c_production = Aws::RDS::Client.new(@production_creds)
         puts "setup_aws_credentials_and_configs production"
+        puts @production_creds
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
         puts "setup_aws_credentials_and_configs else production"
+        puts @production_creds
       end
 
       @aws_production_bucket = @config["aws_production_bucket"]

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -86,9 +86,6 @@ module AwsOneClickStaging
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
-        puts "setup_aws_credentials_and_configs else production"
-        puts "@staging_creds and @staging_creds:"
-        puts @production_creds
       end
 
       @aws_production_bucket = @config["aws_production_bucket"]
@@ -101,6 +98,7 @@ module AwsOneClickStaging
 
     def setup_aws_credentials config
       cred_hash = {}
+
       aws_region = config["aws_region"]
 
       missing = CREDENTIAL_KEYS.select do |key|
@@ -118,7 +116,6 @@ module AwsOneClickStaging
       end
 
       if missing.none?
-        puts "setup_aws_credentials missing.none?"
         access_key_id = config["aws_access_key_id"]
         secret_access_key = config["aws_secret_access_key"]
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
@@ -132,7 +129,6 @@ module AwsOneClickStaging
       cred_hash.update(region: aws_region)
 
       if config['role_arn']
-        puts "setup_aws_credentials role_arn"
         sts = Aws::STS::Client.new(credentials: Aws::RDS::Client.new(cred_hash).config.credentials, region: aws_region)
         cred_hash = {
           credentials: Aws::AssumeRoleCredentials.new(
@@ -143,6 +139,7 @@ module AwsOneClickStaging
           region: aws_region,
         }
       end
+
       cred_hash
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -61,7 +61,7 @@ module AwsOneClickStaging
 
       delete_encrypted_copy!
       create_encrypted_snapshot_copy!
-      delete_snapshot_for_staging!
+#      delete_snapshot_for_staging!
       true
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -125,10 +125,10 @@ module AwsOneClickStaging
         secret_access_key = config["aws_secret_access_key"]
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
       end
-      #if missing.any? && `ec2metadata 2>/dev/null`.empty?
-      #puts "setup_aws_credentials missing.any?"
-      #  raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
-      #end
+      if missing.any? && `ec2metadata 2>/dev/null`.empty?
+      puts "setup_aws_credentials missing.any?"
+        raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
+      end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?
         aws_region = `ec2metadata --availability-zone`.chomp[0..-2]
         puts "setup_aws_credentials !config region && !ec2metadata"

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -82,6 +82,7 @@ module AwsOneClickStaging
     def setup_aws_credentials_and_configs
       puts "setup_aws_credentials_and_configs"
       @staging_creds = setup_aws_credentials(@config['staging'] || @config)
+      puts "@staging_creds:"
       puts @staging_creds
       Aws.config.update @staging_creds
       @c_staging = Aws::RDS::Client.new
@@ -89,11 +90,13 @@ module AwsOneClickStaging
         @production_creds = setup_aws_credentials(@config['production'])
         @c_production = Aws::RDS::Client.new(@production_creds)
         puts "setup_aws_credentials_and_configs production"
+        puts "@staging_creds:"
         puts @production_creds
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
         puts "setup_aws_credentials_and_configs else production"
+        puts "@staging_creds:"
         puts @production_creds
       end
 
@@ -107,6 +110,7 @@ module AwsOneClickStaging
 
     def setup_aws_credentials config
       puts "setup_aws_credentials"
+      puts "config:"
       puts config
       cred_hash = {}
       aws_region = config["aws_region"]
@@ -126,10 +130,12 @@ module AwsOneClickStaging
       end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?
         aws_region = `ec2metadata --availability-zone`.chomp[0..-2]
+        puts "setup_aws_credentials !config region && !ec2metadata"
       end
       cred_hash.update(region: aws_region)
 
       if config['role_arn']
+        puts "setup_aws_credentials role_arn"
         sts = Aws::STS::Client.new(credentials: Aws::RDS::Client.new(cred_hash).config.credentials, region: aws_region)
         cred_hash = {
           credentials: Aws::AssumeRoleCredentials.new(
@@ -140,7 +146,8 @@ module AwsOneClickStaging
           region: aws_region,
         }
       end
-
+      puts "setup_aws_credentials cred_hash:"
+      puts cred_hash
       cred_hash
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -14,9 +14,12 @@ module AwsOneClickStaging
     def initialize file: nil, config: nil
       if config
         @config = config
+        puts "initialize @config = config"
       else
         @config = ConfigFile.load(file)
+        puts "initialize else @config = config"
       end
+      puts @config
       setup_aws_credentials_and_configs
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -288,10 +288,12 @@ module AwsOneClickStaging
     end
 
     def get_fresh_db_instance_state(db_instance_id)
+      puts "get_fresh_db_instance_state"
       @c_staging.describe_db_instances(db_instance_identifier: db_instance_id).db_instances.first
     end
 
     def db_instance_is_deleted?(db_instance_id)
+      puts "db_instance_is_deleted?"
       get_fresh_db_instance_state(db_instance_id)
       false
     rescue Aws::RDS::Errors::DBInstanceNotFound

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -90,13 +90,13 @@ module AwsOneClickStaging
         @production_creds = setup_aws_credentials(@config['production'])
         @c_production = Aws::RDS::Client.new(@production_creds)
         puts "setup_aws_credentials_and_configs production"
-        puts "@staging_creds:"
+        puts "@production_creds:"
         puts @production_creds
       else
         @production_creds = @staging_creds
         @c_production = @c_staging
         puts "setup_aws_credentials_and_configs else production"
-        puts "@staging_creds:"
+        puts "@staging_creds and @staging_creds:"
         puts @production_creds
       end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -207,6 +207,7 @@ module AwsOneClickStaging
 
     def create_encrypted_snapshot_copy!
       puts 'copying shared encrypted snapshot...'
+      puts @c_staging
 
       @c_staging.copy_db_snapshot(
         source_db_snapshot_identifier: "arn:aws:rds:#{Aws.config[:region]}:#{@config['production']['account_id']}:snapshot:#{@db_snapshot_id}",

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -103,19 +103,22 @@ module AwsOneClickStaging
     end
 
     def setup_aws_credentials config
-      cred_hash = {}
+      puts "setup_aws_credentials"
       puts config
+      cred_hash = {}
       aws_region = config["aws_region"]
 
       missing = CREDENTIAL_KEYS.select do |key|
         !config[key]
       end
       if missing.none?
+        puts "setup_aws_credentials missing.none?"
         access_key_id = config["aws_access_key_id"]
         secret_access_key = config["aws_secret_access_key"]
         cred_hash.update(credentials: Aws::Credentials.new(access_key_id, secret_access_key))
       end
       if missing.any? && `ec2metadata 2>/dev/null`.empty?
+      puts "setup_aws_credentials missing.any?"
         raise BadConfiguration, "The following required keys are missing: #{missing.join(', ')}"
       end
       if !config["aws_region"] && !`ec2metadata 2>/dev/null`.empty?


### PR DESCRIPTION
ec2metadata will work only if we run on EC2.
They would like to raise an error if there are missing credentials and we are not on EC2 that might have IAM role,
So now we support the case of credentials preconfigured in any way.