### PR TITLE
gemspec:  spec.add_dependency 'aws-sdk-core'

### DIFF
--- a/aws_one_click_staging.gemspec
+++ b/aws_one_click_staging.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-rds', '~> 1.61.0'
   spec.add_dependency 'aws-sdk-s3', '~> 1.86.2'
+  spec.add_dependency 'aws-sdk-core'
   spec.add_dependency "thor"
   spec.add_dependency "thwait"
 


### PR DESCRIPTION
instead of using gem aws-sdk in staging-builder, user here the specific aws-sdk-core